### PR TITLE
ci: Automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/example-client"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: [ "version-update:semver-major" ]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-api-spec.yml
+++ b/.github/workflows/check-api-spec.yml
@@ -28,3 +28,17 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm run validate
+
+  automerge:
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3.12.0
+        with:
+          target: minor
+          use-github-auto-merge: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Configure Dependabot to open daily dependency update PRs for the example client and GitHub Actions.
- Enable auto-merge for eligible Dependabot PRs after the API spec validation workflow succeeds.

## Technical details
- Adds `.github/dependabot.yml` with npm updates for `/example-client` and GitHub Actions updates for `/`, both labeled `dependencies` and using a 7-day cooldown.
- Ignores semver-major `@types/node` updates to avoid disruptive runtime type jumps.
- Adds a `check-api-spec.yml` `automerge` job gated to Dependabot pull requests, depending on `validate`, and using `fastify/github-action-merge-dependabot` pinned to the v3.12.0 commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency update pull requests for npm packages and GitHub Actions workflows.
  * Enabled automatic merging of eligible dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->